### PR TITLE
Syntax change for ruby 3.2 compatibility

### DIFF
--- a/lib/magentwo.rb
+++ b/lib/magentwo.rb
@@ -11,7 +11,7 @@ module Magentwo
     raise ArgumentError, "no host specified" unless host
     raise ArgumentError, "no user_name specified" unless user_name
     raise ArgumentError, "no password specified" unless password
-    Base.adapter = Adapter.new ({uri: host, user: user_name, password: password})
+    Base.adapter = Adapter.new uri: host, user: user_name, password: password
   end
 
   def self.connect_with_token host=nil, token=nil

--- a/lib/model/stock_item.rb
+++ b/lib/model/stock_item.rb
@@ -7,6 +7,9 @@ module Magentwo
     Attributes.each do |attr| attr_accessor attr end
 
     class << self
+      def unique_identifier
+        :item_id
+      end
     end
   end
 end

--- a/lib/model/stock_item.rb
+++ b/lib/model/stock_item.rb
@@ -8,7 +8,7 @@ module Magentwo
 
     class << self
       def unique_identifier
-        :item_id
+        'item_id'
       end
     end
   end


### PR DESCRIPTION
This was throwing an argument error with the hash syntax. It still appears to work in ruby 2.7.7 with this syntax change.